### PR TITLE
Added a generic z_2_k type

### DIFF
--- a/lattirust-arithmetic/src/decomposition/approximate_balanced_decomposition.rs
+++ b/lattirust-arithmetic/src/decomposition/approximate_balanced_decomposition.rs
@@ -1,0 +1,287 @@
+use std::iter::Sum;
+use std::ops::Mul;
+
+use nalgebra::Scalar;
+use num_bigint::BigUint;
+use num_traits::{One, Signed, ToPrimitive, Zero};
+use rayon::prelude::*;
+use rounded_div::RoundedDiv;
+
+use crate::decomposition::pad_zeros;
+use crate::linear_algebra::{
+    ClosedAddAssign, ClosedMulAssign, Matrix, RowVector, SymmetricMatrix, Vector,
+};
+use crate::ring::representatives::WithSignedRepresentative;
+use crate::ring::{PolyRing, Ring};
+
+use super::{pad_and_transpose, DecompositionFriendlySignedRepresentative};
+
+//include lower bound, exclude upper bound
+pub fn balanced_decomposition_max_length(b: u128, max: BigUint) -> usize {
+    if max.is_zero() {
+        0
+    } else {
+        max.to_f64().unwrap().log(b as f64).floor() as usize + 1 
+    }
+}
+
+// standard base-b expansion (repeated Euclidean division) with digit balanced around zero + OpenFHE twist of dropping first digit
+pub fn approximate_decompose_balanced<R>(v: &R, basis: u128, padding_size: Option<usize>) -> Vec<R>
+where
+    R: Ring + WithSignedRepresentative,
+    R::SignedRepresentative: DecompositionFriendlySignedRepresentative,
+{
+    assert!(
+        !basis.is_zero() && !basis.is_one() && !(basis == 2),
+        "cannot decompose in basis 0,1 or 2"
+    );
+   assert!(basis % 2 == 0, "decomposition basis must be even");
+
+    let basis_half_floor = basis.div_euclid(2);
+    let b  = R::SignedRepresentative::try_from(basis as i128).unwrap();
+    let b_half_floor = R::SignedRepresentative::try_from(basis_half_floor as i128).unwrap();
+
+    let mut curr = Into::<R::SignedRepresentative>::into(*v);
+
+    // approximate gadget decomposition is used; the first digit is ignored
+    let mut rem = curr.clone() % b.clone();
+    if rem.is_negative() { rem = rem + b.clone(); }
+    let r0 = if rem >= b_half_floor.clone() { rem - b.clone() } else { rem };
+    curr = (curr - r0) / b.clone(); 
+
+    let mut decomp_bal_signed = Vec::<R>::new();
+    while !curr.is_zero() {
+        let mut rem = curr.clone() % b.clone();
+        if rem.is_negative() { rem = rem + b.clone(); }
+        let digit = if rem >= b_half_floor.clone() { rem - b.clone() } else { rem };
+
+        decomp_bal_signed.push(R::try_from(digit.clone()).unwrap());
+        curr = (curr - digit) / b.clone();
+    }
+
+    pad_zeros(&mut decomp_bal_signed, padding_size);
+    decomp_bal_signed
+}
+
+pub fn approximate_decompose_balanced_vec<R>(v: &[R], b: u128, padding_size: Option<usize>) -> Vec<Vec<R>>
+where
+    R: Ring + WithSignedRepresentative,
+    R::SignedRepresentative: DecompositionFriendlySignedRepresentative,
+{
+    let decomp: Vec<Vec<R>> = v
+        .par_iter()
+        .map(|v_i| approximate_decompose_balanced(v_i, b, padding_size))
+        .collect(); // v.len() x decomp_size
+    pad_and_transpose(decomp, padding_size) // decomp_size x v.len()
+}
+
+pub fn approximate_decompose_balanced_polyring<PR: PolyRing>(
+    v: &PR,
+    b: u128,
+    padding_size: Option<usize>,
+) -> Vec<PR>
+where
+    PR::BaseRing: WithSignedRepresentative,
+    <PR::BaseRing as WithSignedRepresentative>::SignedRepresentative:
+        DecompositionFriendlySignedRepresentative,
+{
+    approximate_decompose_balanced_vec::<PR::BaseRing>(v.coefficients().as_slice(), b, padding_size)
+        .into_par_iter()
+        .map(|v_i| PR::from(v_i))
+        .collect()
+}
+
+    // Recompose sum_{i=0}^{vec.len()-1} vec[i] * basis^(i + start_pow)
+    pub fn approximate_recompose<A, B>(vec: &[A], basis: B, start_pow: u64) -> A
+    where
+        A: Mul<B, Output = A> + Copy + Sum + Send + Sync,
+        B: Ring,
+    {
+        // Precompute powers: basis^{start_pow}, basis^{start_pow+1}, ...
+        let mut pow = B::one();
+        for _ in 0..start_pow {
+            pow = pow * basis;
+        }
+        let mut powers: Vec<B> = Vec::with_capacity(vec.len());
+        if vec.len() > 0 {
+            powers.push(pow);
+            for _ in 1..vec.len() {
+                pow = pow * basis;
+                powers.push(pow);
+            }
+        }
+
+        vec.par_iter()
+            .zip(powers.par_iter())
+            .map(|(d, p)| (*d) * (*p))
+            .sum()
+    }
+
+    pub fn approximate_decompose_balanced_vec_polyring<PR: PolyRing>(
+    v: &[PR],
+    b: u128,
+    padding_size: Option<usize>,
+) -> Vec<Vector<PR>>
+where
+    PR::BaseRing: WithSignedRepresentative,
+    <PR::BaseRing as WithSignedRepresentative>::SignedRepresentative:
+        DecompositionFriendlySignedRepresentative,
+{
+    let decomp: Vec<Vec<PR>> = v
+        .par_iter()
+        .map(|ring_elem| approximate_decompose_balanced_polyring(ring_elem, b, padding_size))
+        .collect(); // v.len() x decomp_size
+    pad_and_transpose(decomp, padding_size)
+        .into_par_iter()
+        .map(Vector::from)
+        .collect() // decomp_size x v.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use ark_std::test_rng;
+
+    use crate::ring;
+    use crate::ring::ntt::ntt_prime;
+    use crate::ring::pow2_cyclotomic_poly_ring_ntt::Pow2CyclotomicPolyRingNTT;
+    use crate::ring::util::powers_of_basis;
+    use crate::ring::Zq1;
+    use crate::traits::WithLinfNorm;
+
+    use super::*;
+
+    const N: usize = 128;
+    const Q: u64 = ntt_prime::<N>(12);
+    const VEC_LENGTH: usize = 32;
+    const BASIS_TEST_RANGE: [u128; 4] = [4, 8, 16, 32];
+
+    type R = Zq1<Q>;
+    type PolyR = Pow2CyclotomicPolyRingNTT<R, N>;
+
+    fn first_digit_r0<R>(v: &R, b: u128) -> R
+    where
+        R: Ring + WithSignedRepresentative,
+        R::SignedRepresentative: DecompositionFriendlySignedRepresentative,
+    {
+        let bs  = R::SignedRepresentative::try_from(b as i128).unwrap();
+        let bh  = R::SignedRepresentative::try_from((b/2) as i128).unwrap();
+        let mut rem = Into::<R::SignedRepresentative>::into(*v) % bs.clone();
+        if rem.is_negative() { rem = rem + bs.clone(); }
+        let r0s = if rem >= bh { rem - bs } else { rem };
+        R::try_from(r0s).unwrap()
+    }
+
+
+    #[test]
+    fn test_decompose_balanced() {
+        let vs: Vec<R> = (0..Q).map(|v| R::try_from(v).unwrap()).collect();
+        for b in BASIS_TEST_RANGE {
+            for v in &vs {
+                let decomp = approximate_decompose_balanced(v, b, None);
+
+                // Check that the decomposition length is correct
+                let max = v.linf_norm();
+                let max_decomp_length = balanced_decomposition_max_length(b, max);
+                assert!(decomp.len() <= max_decomp_length);
+
+                // Check that all entries are smaller than b/2
+                for v_i in &decomp {
+                    assert!(v_i.linf_norm() <= BigUint::from(b.div_floor(2)));
+                }
+                // Check that the decomposition is 
+                let r0 = first_digit_r0(v, b);
+                assert_eq!(*v, r0 + approximate_recompose(&decomp, R::try_from(b).unwrap(), 1));
+            }
+        }
+    }
+
+    fn get_test_vec() -> [R; N] {
+        core::array::from_fn(|i| R::try_from((i as u64 * Q) / (N as u64)).unwrap())
+    }
+
+    #[test]
+    fn test_decompose_balanced_vec() {
+        let v = get_test_vec();
+        for b in BASIS_TEST_RANGE {
+            let b_half = b / 2;
+            let decomp = approximate_decompose_balanced_vec(&v, b, None);
+
+            // Check that the decomposition length is correct
+            let max = v.linf_norm();
+            let max_decomp_length = balanced_decomposition_max_length(b, max);
+            assert!(decomp.len() <= max_decomp_length);
+
+            // Check that all entries are smaller than b/2 in absolute value
+            for d_i in &decomp {
+                for d_ij in d_i {
+                    assert!(d_ij.linf_norm() <= b_half.into());
+                }
+            }
+
+            for i in 0..decomp.len() {
+                // Check that the decomposition is correct
+                let r0_i = first_digit_r0(&v[i], b);
+                let decomp_i = decomp.iter().map(|d_j| d_j[i]).collect::<Vec<_>>();
+                assert_eq!(v[i],r0_i + approximate_recompose(&decomp_i, R::try_from(b).unwrap(), 1));
+            }
+        }
+    }
+
+    #[test]
+    fn test_decompose_balanced_polyring() {
+        let v = PolyR::from_coefficient_array(get_test_vec());
+        for b in BASIS_TEST_RANGE {
+            let b_half = b / 2;
+            let decomp: Vec<PolyR> = approximate_decompose_balanced_polyring(&v, b, None);
+
+            for d_i in &decomp {
+                for d_ij in d_i.coefficients() {
+                    assert!(d_ij.linf_norm() <= b_half.into());
+                }
+            }
+            let r0_coeffs: Vec<R> = v.coefficients().iter().map(|c| first_digit_r0(c, b)).collect();
+            let r0_poly = PolyR::try_from_coefficients(r0_coeffs.as_slice()).unwrap();
+
+            assert_eq!(v,r0_poly + approximate_recompose(&decomp, R::try_from(b).unwrap(), 1));
+        }
+    }
+
+    #[test]
+    fn test_decompose_balanced_vec_polyring() {
+        let v = Vector::<PolyR>::from_fn(VEC_LENGTH, |i, _| {
+            PolyR::try_from_coefficients(
+                get_test_vec()
+                    .into_iter()
+                    .map(|v| v + R::try_from(i as u64).unwrap())
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )
+            .unwrap()
+        });
+        for b in BASIS_TEST_RANGE {
+            let b_half = b / 2;
+            let decomp = approximate_decompose_balanced_vec_polyring::<PolyR>(&v.as_slice(), b, None);
+
+            for v_i in &decomp {
+                for v_ij in v_i.as_slice() {
+                    for v_ijk in v_ij.coefficients() {
+                        assert!(v_ijk.linf_norm() <= b_half.into());
+                    }
+                }
+            }
+
+            let r0_vec = Vector::<PolyR>::from_fn(VEC_LENGTH, |i, _| {
+                let coeffs: Vec<R> = v[i].coefficients().iter().map(|c| first_digit_r0(c, b)).collect();
+                PolyR::try_from_coefficients(coeffs.as_slice()).unwrap()
+            });
+
+            let mut recomposed = r0_vec.clone();
+            for (i, v_i) in decomp.iter().enumerate() {
+                recomposed +=
+                    v_i * PolyR::from_scalar(Ring::pow(&R::try_from(b).unwrap(), i as u64 + 1));
+            }
+            assert_eq!(v, recomposed);
+        }
+    }
+
+}

--- a/lattirust-arithmetic/src/decomposition/approximate_balanced_decomposition.rs
+++ b/lattirust-arithmetic/src/decomposition/approximate_balanced_decomposition.rs
@@ -46,14 +46,14 @@ where
     // approximate gadget decomposition is used; the first digit is ignored
     let mut rem = curr.clone() % b.clone();
     if rem.is_negative() { rem = rem + b.clone(); }
-    let r0 = if rem >= b_half_floor.clone() { rem - b.clone() } else { rem };
+    let r0 = if rem > b_half_floor.clone() { rem - b.clone() } else { rem };
     curr = (curr - r0) / b.clone(); 
 
     let mut decomp_bal_signed = Vec::<R>::new();
     while !curr.is_zero() {
         let mut rem = curr.clone() % b.clone();
         if rem.is_negative() { rem = rem + b.clone(); }
-        let digit = if rem >= b_half_floor.clone() { rem - b.clone() } else { rem };
+        let digit = if rem > b_half_floor.clone() { rem - b.clone() } else { rem };
 
         decomp_bal_signed.push(R::try_from(digit.clone()).unwrap());
         curr = (curr - digit) / b.clone();
@@ -167,7 +167,7 @@ mod tests {
         let bh  = R::SignedRepresentative::try_from((b/2) as i128).unwrap();
         let mut rem = Into::<R::SignedRepresentative>::into(*v) % bs.clone();
         if rem.is_negative() { rem = rem + bs.clone(); }
-        let r0s = if rem >= bh { rem - bs } else { rem };
+        let r0s = if rem > bh { rem - bs } else { rem };
         R::try_from(r0s).unwrap()
     }
 

--- a/lattirust-arithmetic/src/decomposition/mod.rs
+++ b/lattirust-arithmetic/src/decomposition/mod.rs
@@ -13,6 +13,7 @@ use crate::linear_algebra::{
 };
 use crate::ring::Ring;
 
+pub mod approximate_balanced_decomposition;
 pub mod balanced_decomposition;
 #[allow(clippy::module_inception)]
 pub mod decomposition;

--- a/lattirust-arithmetic/src/linear_algebra/mod.rs
+++ b/lattirust-arithmetic/src/linear_algebra/mod.rs
@@ -1,6 +1,6 @@
 use std::ops::{Add, Mul, Sub};
 
-mod generic_matrix;
+pub mod generic_matrix;
 pub mod inner_products;
 mod matrix;
 pub mod serialization;

--- a/lattirust-arithmetic/src/ring/f_p.rs
+++ b/lattirust-arithmetic/src/ring/f_p.rs
@@ -62,6 +62,14 @@ impl<C: FpConfig<N>, const N: usize> WithSignedRepresentative for Fp<C, N> {
     fn as_signed_representative(&self) -> Self::SignedRepresentative {
         (*self).into()
     }
+
+    fn signed_representative_to_bigint(repr: &Self::SignedRepresentative) ->num_bigint::BigInt {
+        repr.0.clone()  
+    }
+    
+    fn signed_representative_from_bigint(value: num_bigint::BigInt) -> Option<Self::SignedRepresentative> {
+        Some(SignedRepresentative::new(value))
+    }
 }
 
 #[cfg(test)]

--- a/lattirust-arithmetic/src/ring/mod.rs
+++ b/lattirust-arithmetic/src/ring/mod.rs
@@ -23,7 +23,7 @@ pub use z_q::*;
 use crate::nimue::serialization::{FromBytes, ToBytes};
 use crate::traits::{FromRandomBytes, Modulus, WithL2Norm, WithLinfNorm};
 
-mod f_p;
+pub mod f_p;
 pub mod ntt;
 mod poly_ring;
 pub(crate) mod pow2_cyclotomic_poly_ring;

--- a/lattirust-arithmetic/src/ring/mod.rs
+++ b/lattirust-arithmetic/src/ring/mod.rs
@@ -19,6 +19,7 @@ pub use z_2::*;
 pub use z_2_128::*;
 pub use z_2_64::*;
 pub use z_q::*;
+//pub use z_2_k::*;
 
 use crate::nimue::serialization::{FromBytes, ToBytes};
 use crate::traits::{FromRandomBytes, Modulus, WithL2Norm, WithLinfNorm};
@@ -34,6 +35,7 @@ mod z_2;
 mod z_2_128;
 mod z_2_64;
 mod z_q;
+mod z_2_k;
 // pub mod pow2_cyclotomic_poly_ring_ntt_crt;
 
 pub trait Ring:
@@ -226,6 +228,9 @@ macro_rules! test_distributive {
                 let b = <$T as UniformRand>::rand(rng);
                 let c = <$T as UniformRand>::rand(rng);
 
+                println!("Testing distributive property for {:?}", a);
+                print!("b: {:?}", b);
+                print!("c: {:?}", c);
                 assert_eq!(a * (b + c), (a * b) + (a * c));
                 assert_eq!((a + b) * c, (a * c) + (b * c));
             }
@@ -343,6 +348,8 @@ macro_rules! test_inverse_multiplication_ring {
             for _ in 0..$N {
                 let a = <$T as UniformRand>::rand(rng);
                 let inv = <$T as Ring>::inverse(&a);
+                println!("Testing inverse multiplication for {:?}", a);
+                println!("Inverse: {:?}", inv);
                 if inv.is_some() {
                     assert_eq!(a * inv.unwrap(), <$T>::one());
                     assert_eq!(inv.unwrap() * a, <$T>::one());

--- a/lattirust-arithmetic/src/ring/mod.rs
+++ b/lattirust-arithmetic/src/ring/mod.rs
@@ -35,7 +35,7 @@ mod z_2;
 mod z_2_128;
 mod z_2_64;
 mod z_q;
-mod z_2_k;
+pub mod z_2_k;
 // pub mod pow2_cyclotomic_poly_ring_ntt_crt;
 
 pub trait Ring:

--- a/lattirust-arithmetic/src/ring/mod.rs
+++ b/lattirust-arithmetic/src/ring/mod.rs
@@ -19,7 +19,7 @@ pub use z_2::*;
 pub use z_2_128::*;
 pub use z_2_64::*;
 pub use z_q::*;
-//pub use z_2_k::*;
+pub use z_2_k::*;
 
 use crate::nimue::serialization::{FromBytes, ToBytes};
 use crate::traits::{FromRandomBytes, Modulus, WithL2Norm, WithLinfNorm};

--- a/lattirust-arithmetic/src/ring/mod.rs
+++ b/lattirust-arithmetic/src/ring/mod.rs
@@ -20,6 +20,7 @@ pub use z_2_128::*;
 pub use z_2_64::*;
 pub use z_q::*;
 pub use z_2_k::*;
+pub use f_p::FromZqSignedRepresentative;
 
 use crate::nimue::serialization::{FromBytes, ToBytes};
 use crate::traits::{FromRandomBytes, Modulus, WithL2Norm, WithLinfNorm};

--- a/lattirust-arithmetic/src/ring/ntt.rs
+++ b/lattirust-arithmetic/src/ring/ntt.rs
@@ -247,7 +247,7 @@ pub const fn generator<const Q: u64>() -> u64 {
 }
 
 //Special case for interoperability with Openfhe
-const fn selected_two_nth_root<const Q: u64, const N: usize>() -> u64 {
+pub const fn selected_two_nth_root<const Q: u64, const N: usize>() -> u64 {
     if Q == 134_215_681 && N == 512 { 78_074 } else { two_nth_primitive_root_of_unity::<Q, N>() }
 }
 

--- a/lattirust-arithmetic/src/ring/ntt.rs
+++ b/lattirust-arithmetic/src/ring/ntt.rs
@@ -251,14 +251,14 @@ pub const fn selected_two_nth_root<const Q: u64, const N: usize>() -> u64 {
     if Q == 134_215_681 && N == 512 { 78_074 } else { two_nth_primitive_root_of_unity::<Q, N>() }
 }
 
-struct RootOfUnity<const Q: u64, const N: usize> {}
+pub struct RootOfUnity<const Q: u64, const N: usize> {}
 
 impl<const Q: u64, const N: usize> RootOfUnity<Q, N> {
-    const ROOT_OF_UNITY: u64 = selected_two_nth_root::<Q, N>();
-    const POWS_ROOT_OF_UNITY_BIT_REVERSED: [Fq<Q>; N] = pows_bit_reversed(Self::ROOT_OF_UNITY);
-    const NEG_POWS_ROOT_OF_UNITY_BIT_REVERSED: [Fq<Q>; N] =
+    pub const ROOT_OF_UNITY: u64 = selected_two_nth_root::<Q, N>();
+    pub const POWS_ROOT_OF_UNITY_BIT_REVERSED: [Fq<Q>; N] = pows_bit_reversed(Self::ROOT_OF_UNITY);
+    pub const NEG_POWS_ROOT_OF_UNITY_BIT_REVERSED: [Fq<Q>; N] =
         pows_bit_reversed(const_inv_mod::<Q>(Self::ROOT_OF_UNITY));
-    const N_INV_MOD_Q: Fq<Q> = const_fq_from(const_inv_mod::<Q>(N as u64));
+    pub const N_INV_MOD_Q: Fq<Q> = const_fq_from(const_inv_mod::<Q>(N as u64));
 }
 
 impl<const Q: u64, const N: usize> Ntt<N> for Fq<Q> {

--- a/lattirust-arithmetic/src/ring/ntt.rs
+++ b/lattirust-arithmetic/src/ring/ntt.rs
@@ -246,10 +246,15 @@ pub const fn generator<const Q: u64>() -> u64 {
     panic!("no generator found");
 }
 
+//Special case for interoperability with Openfhe
+const fn selected_two_nth_root<const Q: u64, const N: usize>() -> u64 {
+    if Q == 134_215_681 && N == 512 { 78_074 } else { two_nth_primitive_root_of_unity::<Q, N>() }
+}
+
 struct RootOfUnity<const Q: u64, const N: usize> {}
 
 impl<const Q: u64, const N: usize> RootOfUnity<Q, N> {
-    const ROOT_OF_UNITY: u64 = two_nth_primitive_root_of_unity::<Q, N>();
+    const ROOT_OF_UNITY: u64 = selected_two_nth_root::<Q, N>();
     const POWS_ROOT_OF_UNITY_BIT_REVERSED: [Fq<Q>; N] = pows_bit_reversed(Self::ROOT_OF_UNITY);
     const NEG_POWS_ROOT_OF_UNITY_BIT_REVERSED: [Fq<Q>; N] =
         pows_bit_reversed(const_inv_mod::<Q>(Self::ROOT_OF_UNITY));

--- a/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring.rs
+++ b/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring.rs
@@ -41,7 +41,7 @@ impl<BaseRing: Ring, const N: usize> Pow2CyclotomicPolyRing<BaseRing, N> {
         Self(Self::Inner::const_from_array(coeffs))
     }
 
-    pub(crate) fn coefficient_array(&self) -> [BaseRing; N] {
+    pub fn coefficient_array(&self) -> [BaseRing; N] {
         self.0 .0.into()
     }
 

--- a/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring.rs
+++ b/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring.rs
@@ -69,23 +69,6 @@ impl<BaseRing: Ring, const N: usize> Pow2CyclotomicPolyRing<BaseRing, N> {
         (Self::from(quotient), Self::from(dividend))
     }
 
-    // Apply negacyclic transposition: [a0, a1, ..., a_{n-1}] -> [a0, -a_{n-1}, -a_{n-2}, ..., -a1]
-    fn transpose_negacyclic(&self) -> Self {
-        let coeffs = self.coefficient_array();
-        let mut result = [BaseRing::ZERO; N];
-        
-        result[0] = coeffs[0];
-        for i in 1..N {
-            result[i] = -coeffs[N - i];
-        }
-        
-        Self::from(result)
-    }
-    
-    // Apply negacyclic transposition in-place
-    pub fn transpose_negacyclic_inplace(&mut self) {
-        *self = self.transpose_negacyclic();
-    }
 }
 
 impl<BaseRing: Ring, const N: usize> From<[BaseRing; N]> for Pow2CyclotomicPolyRing<BaseRing, N> {
@@ -495,4 +478,5 @@ mod test {
     test_polyring!(PR, NUM_TEST_REPETITIONS);
 
     test_conjugation_automorphism!(PR, NUM_TEST_REPETITIONS);
+
 }

--- a/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring.rs
+++ b/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring.rs
@@ -68,6 +68,24 @@ impl<BaseRing: Ring, const N: usize> Pow2CyclotomicPolyRing<BaseRing, N> {
 
         (Self::from(quotient), Self::from(dividend))
     }
+
+    // Apply negacyclic transposition: [a0, a1, ..., a_{n-1}] -> [a0, -a_{n-1}, -a_{n-2}, ..., -a1]
+    fn transpose_negacyclic(&self) -> Self {
+        let coeffs = self.coefficient_array();
+        let mut result = [BaseRing::ZERO; N];
+        
+        result[0] = coeffs[0];
+        for i in 1..N {
+            result[i] = -coeffs[N - i];
+        }
+        
+        Self::from(result)
+    }
+    
+    // Apply negacyclic transposition in-place
+    pub fn transpose_negacyclic_inplace(&mut self) {
+        *self = self.transpose_negacyclic();
+    }
 }
 
 impl<BaseRing: Ring, const N: usize> From<[BaseRing; N]> for Pow2CyclotomicPolyRing<BaseRing, N> {

--- a/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring_ntt.rs
+++ b/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring_ntt.rs
@@ -80,6 +80,24 @@ impl<BaseRing: NttRing<N>, const N: usize> Pow2CyclotomicPolyRingNTT<BaseRing, N
     pub fn ntt_array(&self) -> [BaseRing; N] {
         self.0 .0.data.0[0]
     }
+
+    // Apply negacyclic transposition: [a0, a1, ..., a_{n-1}] -> [a0, -a_{n-1}, -a_{n-2}, ..., -a1]
+    fn transpose_negacyclic(&self) -> Self {
+        let coeffs = self.ntt_array();
+        let mut result = [BaseRing::ZERO; N];
+        
+        result[0] = coeffs[0];
+        for i in 1..N {
+            result[i] = -coeffs[N - i];
+        }
+        
+        Self::from_ntt_array(result)
+    }
+    
+    // Apply negacyclic transposition in-place
+    pub fn transpose_negacyclic_inplace(&mut self) {
+        *self = self.transpose_negacyclic();
+    }
 }
 
 impl<BaseRing: NttRing<N>, const N: usize> Modulus for Pow2CyclotomicPolyRingNTT<BaseRing, N> {

--- a/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring_ntt.rs
+++ b/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring_ntt.rs
@@ -81,16 +81,14 @@ impl<BaseRing: NttRing<N>, const N: usize> Pow2CyclotomicPolyRingNTT<BaseRing, N
         self.0 .0.data.0[0]
     }
 
-    // Apply negacyclic transposition: [a0, a1, ..., a_{n-1}] -> [a0, -a_{n-1}, -a_{n-2}, ..., -a1]
+    // Apply negacyclic transposition: [a0, a1, ..., a_{n-1}] -> [a0, a_{n-1}, a_{n-2}, ..., a1]
     fn transpose_negacyclic(&self) -> Self {
-        let coeffs = self.ntt_array();
+        let evals = self.ntt_array();
         let mut result = [BaseRing::ZERO; N];
         
-        result[0] = coeffs[0];
-        for i in 1..N {
-            result[i] = -coeffs[N - i];
+        for i in 0..N {
+            result[i] = evals[N - 1 - i];        
         }
-        
         Self::from_ntt_array(result)
     }
     

--- a/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring_ntt.rs
+++ b/lattirust-arithmetic/src/ring/pow2_cyclotomic_poly_ring_ntt.rs
@@ -81,21 +81,6 @@ impl<BaseRing: NttRing<N>, const N: usize> Pow2CyclotomicPolyRingNTT<BaseRing, N
         self.0 .0.data.0[0]
     }
 
-    // Apply negacyclic transposition: [a0, a1, ..., a_{n-1}] -> [a0, a_{n-1}, a_{n-2}, ..., a1]
-    fn transpose_negacyclic(&self) -> Self {
-        let evals = self.ntt_array();
-        let mut result = [BaseRing::ZERO; N];
-        
-        for i in 0..N {
-            result[i] = evals[N - 1 - i];        
-        }
-        Self::from_ntt_array(result)
-    }
-    
-    // Apply negacyclic transposition in-place
-    pub fn transpose_negacyclic_inplace(&mut self) {
-        *self = self.transpose_negacyclic();
-    }
 }
 
 impl<BaseRing: NttRing<N>, const N: usize> Modulus for Pow2CyclotomicPolyRingNTT<BaseRing, N> {
@@ -467,7 +452,7 @@ impl<BaseRing: NttRing<N>, const N: usize> From<BaseRing>
     fn from(value: BaseRing) -> Self {
         Self::from_scalar(value)
     }
-}
+} 
 
 impl<BaseRing: NttRing<N>, const N: usize> WithConjugationAutomorphism
     for Pow2CyclotomicPolyRingNTT<BaseRing, N>
@@ -530,6 +515,15 @@ mod test {
             assert_eq!(p, p_);
         }
     }
+    fn reverse_ntt(ntt_poly: &PR) -> PR {
+        let evals = ntt_poly.ntt_array();
+        let mut reversed = [BR::ZERO; N];
+        for i in 0..N {
+            reversed[i] = evals[N - 1 - i];
+        }
+        PR::from_ntt_array(reversed)
+    }
+    
 
     test_conjugation_automorphism!(PR, NUM_TEST_REPETITIONS);
 }

--- a/lattirust-arithmetic/src/ring/representatives.rs
+++ b/lattirust-arithmetic/src/ring/representatives.rs
@@ -28,6 +28,9 @@ pub trait WithSignedRepresentative: Sized + Clone {
     fn as_signed_representative(&self) -> Self::SignedRepresentative {
         (*self).clone().into()
     }
+
+    fn signed_representative_to_bigint(repr: &Self::SignedRepresentative) -> BigInt;
+    fn signed_representative_from_bigint(value: BigInt) -> Option<Self::SignedRepresentative>;
 }
 
 /// For an odd prime [P], the signed representative of an element in Z_P is an integer in the range `[-floor(P/2), floor(P/2)]`.
@@ -270,39 +273,6 @@ impl<M: Modulus> TryFrom<i128> for SignedRepresentative<M> {
         }
         Ok(Self::new(BigInt::from(value)))
     }
-}
-
-macro_rules! signed_rep_to_primitive_signed {
-    ($($t:ty),*) => {
-        $(
-            paste::paste! {
-                fn [<to_ $t>](&self) -> Option<$t> {
-                    self.0.[<to_ $t>]()
-                }
-            }
-        )*
-    };
-}
-
-macro_rules! signed_rep_to_primitive_unsigned {
-    ($($t:ty),*) => {
-        $(
-            paste::paste! {
-                fn [<to_ $t>](&self) -> Option<$t> {
-                    if self.0.is_negative() {
-                        None
-                    } else {
-                        self.0.[<to_ $t>]()
-                    }
-                }
-            }
-        )*
-    };
-}
-
-impl<M: Modulus> ToPrimitive for SignedRepresentative<M> {
-    signed_rep_to_primitive_signed!(i8, i16, i32, i64, i128, isize);
-    signed_rep_to_primitive_unsigned!(u8, u16, u32, u64, u128, usize);
 }
 
 #[macro_export]

--- a/lattirust-arithmetic/src/ring/representatives.rs
+++ b/lattirust-arithmetic/src/ring/representatives.rs
@@ -272,6 +272,39 @@ impl<M: Modulus> TryFrom<i128> for SignedRepresentative<M> {
     }
 }
 
+macro_rules! signed_rep_to_primitive_signed {
+    ($($t:ty),*) => {
+        $(
+            paste::paste! {
+                fn [<to_ $t>](&self) -> Option<$t> {
+                    self.0.[<to_ $t>]()
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! signed_rep_to_primitive_unsigned {
+    ($($t:ty),*) => {
+        $(
+            paste::paste! {
+                fn [<to_ $t>](&self) -> Option<$t> {
+                    if self.0.is_negative() {
+                        None
+                    } else {
+                        self.0.[<to_ $t>]()
+                    }
+                }
+            }
+        )*
+    };
+}
+
+impl<M: Modulus> ToPrimitive for SignedRepresentative<M> {
+    signed_rep_to_primitive_signed!(i8, i16, i32, i64, i128, isize);
+    signed_rep_to_primitive_unsigned!(u8, u16, u32, u64, u128, usize);
+}
+
 #[macro_export]
 macro_rules! test_signed_representative {
     ($t:ty, $n:expr) => {

--- a/lattirust-arithmetic/src/ring/z_2_128.rs
+++ b/lattirust-arithmetic/src/ring/z_2_128.rs
@@ -12,7 +12,7 @@ use derive_more::{
     Add, AddAssign, Display, From, Into, Mul, MulAssign, Neg, Product, Sub, SubAssign, Sum,
 };
 use i256::i256;
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
 use num_traits::{One, ToPrimitive, Zero};
 use zeroize::Zeroize;
 
@@ -275,6 +275,14 @@ impl WithSignedRepresentative for Z2_128 {
 
     fn as_signed_representative(&self) -> Self::SignedRepresentative {
         self.0 .0
+    }
+
+    fn signed_representative_to_bigint(repr: &Self::SignedRepresentative) -> BigInt {
+        BigInt::from(*repr)
+    }
+    
+    fn signed_representative_from_bigint(value: BigInt) -> Option<Self::SignedRepresentative> {
+        value.to_i128()
     }
 }
 

--- a/lattirust-arithmetic/src/ring/z_2_64.rs
+++ b/lattirust-arithmetic/src/ring/z_2_64.rs
@@ -11,7 +11,7 @@ use ark_std::UniformRand;
 use derive_more::{
     Add, AddAssign, Display, From, Into, Mul, MulAssign, Neg, Product, Sub, SubAssign, Sum,
 };
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
 use num_traits::{One, ToPrimitive, Zero};
 use zeroize::Zeroize;
 
@@ -273,6 +273,14 @@ impl WithSignedRepresentative for Z2_64 {
 
     fn as_signed_representative(&self) -> Self::SignedRepresentative {
         self.0 .0
+    }
+
+    fn signed_representative_to_bigint(repr: &Self::SignedRepresentative) -> BigInt {
+        BigInt::from(*repr)
+    }
+    
+    fn signed_representative_from_bigint(value: BigInt) -> Option<Self::SignedRepresentative> {
+        value.to_i64()
     }
 }
 

--- a/lattirust-arithmetic/src/ring/z_2_k.rs
+++ b/lattirust-arithmetic/src/ring/z_2_k.rs
@@ -11,7 +11,7 @@ use ark_std::UniformRand;
 use derive_more::{ Display, From, Into, Neg, Product, Sum,
 };
 use i256::i256;
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
 use num_traits::{One, ToPrimitive, Zero};
 use zeroize::Zeroize;
 
@@ -347,6 +347,14 @@ impl<const K: u32> WithSignedRepresentative for Z2_k<K> {
 
     fn as_signed_representative(&self) -> Self::SignedRepresentative {
         self.0 .0
+    }
+
+    fn signed_representative_to_bigint(repr: &Self::SignedRepresentative) -> BigInt {
+        BigInt::from(*repr)
+    }
+    
+    fn signed_representative_from_bigint(value: BigInt) -> Option<Self::SignedRepresentative> {
+        value.to_i128()
     }
 }
 

--- a/lattirust-arithmetic/src/ring/z_2_k.rs
+++ b/lattirust-arithmetic/src/ring/z_2_k.rs
@@ -8,8 +8,7 @@ use ark_serialize::{
 };
 use ark_std::rand::Rng;
 use ark_std::UniformRand;
-use derive_more::{
-    Add, AddAssign, Display, From, Into, Mul, MulAssign, Neg, Product, Sub, SubAssign, Sum,
+use derive_more::{ Display, From, Into, Neg, Product, Sum,
 };
 use i256::i256;
 use num_bigint::BigUint;
@@ -41,14 +40,14 @@ pub struct Z2_k<const K: u32>(Wrapping<i128>);
 
 impl<const K: u32> Z2_k<K> {
     //ensures values don't exceed the modulus
-    const ASSERT_K_VALID: () = {
+    const _ASSERT_K_VALID: () = {
         assert!(K > 0 && K <= 128, "K must be between 1 and 128");
     };
-    const _VALIDATE: () = Self::ASSERT_K_VALID;
+    const _VALIDATE: () = Self::_ASSERT_K_VALID;
 
     const MODULUS_HALF: u128 = 1u128 << (K - 1);
 
-    /// Reduce the value to fit within the range of the ring. Ensures: a * 1/a mod 2^k = 1
+    // Reduce the value to fit within the range of the ring
     fn reduce(value: i128) -> i128 {
         if K >= 128 {
             value

--- a/lattirust-arithmetic/src/ring/z_2_k.rs
+++ b/lattirust-arithmetic/src/ring/z_2_k.rs
@@ -1,0 +1,389 @@
+use std::io::{Read, Write};
+use std::iter::{Product, Sum};
+use std::num::Wrapping;
+use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
+
+use ark_serialize::{
+    CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Valid, Validate,
+};
+use ark_std::rand::Rng;
+use ark_std::UniformRand;
+use derive_more::{
+    Add, AddAssign, Display, From, Into, Mul, MulAssign, Neg, Product, Sub, SubAssign, Sum,
+};
+use i256::i256;
+use num_bigint::BigUint;
+use num_traits::{One, ToPrimitive, Zero};
+use zeroize::Zeroize;
+
+use crate::ring::representatives::WithSignedRepresentative;
+use crate::ring::Ring;
+use crate::traits::{FromRandomBytes, Modulus};
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Display,
+    From,
+    Into,
+    Hash,
+    Default,
+    PartialOrd,
+    Ord,
+    Neg,
+    Sum,
+    Product,
+    Zeroize,
+)]
+#[repr(transparent)]
+pub struct Z2_k<const K: u32>(Wrapping<i128>);
+
+impl<const K: u32> Z2_k<K> {
+    //ensures values don't exceed the modulus
+    const ASSERT_K_VALID: () = {
+        assert!(K > 0 && K <= 128, "K must be between 1 and 128");
+    };
+    const _VALIDATE: () = Self::ASSERT_K_VALID;
+
+    const MODULUS_HALF: u128 = 1u128 << (K - 1);
+
+    /// Reduce the value to fit within the range of the ring. Ensures: a * 1/a mod 2^k = 1
+    fn reduce(value: i128) -> i128 {
+        if K >= 128 {
+            value
+        } else {
+            let mask = (1u128 << K) - 1;
+            let unsigned = value as u128 & mask;
+            let modulus_half = Self::MODULUS_HALF;
+
+            if unsigned < modulus_half {
+                unsigned as i128
+            } else {
+                (unsigned as i128) - (1i128 << K)
+            }
+        }
+    }
+}
+
+impl<const K: u32> Zero for Z2_k<K> {
+    fn zero() -> Self {
+        Self(Wrapping(0))
+    }
+
+    fn is_zero(&self) -> bool {
+        self.0 == Wrapping(0)
+    }
+}
+
+impl<const K: u32> One for Z2_k<K> {
+    fn one() -> Self {
+        Self(Wrapping(1))
+    }
+}
+
+impl<const K: u32> Mul for Z2_k<K> {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let result = self.0 .0.wrapping_mul(rhs.0 .0);
+        Self(Wrapping(Self::reduce(result)))
+    }
+}
+
+impl<const K: u32> MulAssign for Z2_k<K> {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<const K: u32> Add for Z2_k<K> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let result = self.0.0.wrapping_add(rhs.0.0);
+        Self(Wrapping(Self::reduce(result)))
+    }
+}
+
+impl<const K: u32> Sub for Z2_k<K> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let result = self.0.0.wrapping_sub(rhs.0.0);
+        Self(Wrapping(Self::reduce(result)))
+    }
+}
+
+impl<const K: u32> AddAssign for Z2_k<K> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<const K: u32> SubAssign for Z2_k<K> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<const K: u32> PartialEq for Z2_k<K> {
+    fn eq(&self, other: &Self) -> bool {
+        Self::reduce(self.0.0) == Self::reduce(other.0.0)
+    }
+}
+
+impl<const K: u32> Eq for Z2_k<K> {}
+
+/// Map `[0, MODULUS_HALF) <-> [0, MODULUS_HALF)` and `[-MODULUS_HALF, 0) <-> [MODULUS_HALF, MODULUS)`
+macro_rules! from_primitive_type {
+    ($($t:ty),*) => {
+        $(
+            impl<const K: u32> From<$t> for Z2_k<K> {
+                fn from(x: $t) -> Self {
+                    let unsigned = x as u128;
+                    let modulus_half = Self::MODULUS_HALF;
+                    let signed: i128 = if unsigned < modulus_half {
+                        unsigned as i128
+                    } else {
+                        let unsigned_256 = i256::from_u128(unsigned);
+                        let modulus = i256::from_u8(1u8) << K;
+                        let res: i256 = unsigned_256.sub(modulus);
+                        res.as_i128()
+                    };
+                    Self(Wrapping(signed as i128))
+                }
+            }
+        )*
+    }
+}
+
+/// Map `[0, MODULUS_HALF) <-> [0, MODULUS_HALF)` and `[-MODULUS_HALF, 0) <-> [MODULUS_HALF, MODULUS)`
+macro_rules! into_primitive_type {
+    ($($t:ty),*) => {
+        $(
+            impl<const K: u32> From<Z2_k<K>> for $t {
+                fn from(x: Z2_k<K>) -> Self {
+                    let signed = x.0 .0;
+                    let unsigned: u128 = if signed >= 0 {
+                        signed as u128
+                    } else {
+                        let signed_256 = i256::from_i128(signed);
+                        let modulus = i256::from_u8(1u8) << K;
+                        let res: i256 = signed_256.add(modulus);
+                        res.as_u128()
+                    };
+                    unsigned as $t
+                }
+            }
+        )*
+    };
+}
+
+from_primitive_type!(bool, u8, u16, u32, u64, u128);
+into_primitive_type!(u8, u16, u32, u64, u128);
+
+impl<const K: u32> Modulus for Z2_k<K> {
+    fn modulus() -> BigUint {
+        BigUint::from(2u8).pow(K)
+    }
+}
+
+impl<const K: u32> CanonicalSerialize for Z2_k<K> {
+    #[inline]
+    fn serialize_with_mode<W: Write>(
+        &self,
+        mut writer: W,
+        _compress: Compress,
+    ) -> Result<(), SerializationError> {
+        Ok(writer.write_all(&self.0 .0.to_le_bytes())?)
+    }
+
+    #[inline]
+    fn serialized_size(&self, _compress: Compress) -> usize {
+        core::mem::size_of::<i128>()
+    }
+}
+
+impl<const K: u32> Valid for Z2_k<K> {
+    #[inline]
+    fn check(&self) -> Result<(), SerializationError> {
+        Ok(())
+    }
+
+    #[inline]
+    fn batch_check<'a>(_batch: impl Iterator<Item = &'a Self>) -> Result<(), SerializationError>
+    where
+        Self: 'a,
+    {
+        Ok(())
+    }
+}
+
+impl<const K: u32> CanonicalDeserialize for Z2_k<K> {
+    fn deserialize_with_mode<R: Read>(
+        mut reader: R,
+        _compress: Compress,
+        _validate: Validate,
+    ) -> Result<Self, SerializationError> {
+        let mut bytes = [0u8; core::mem::size_of::<i128>()];
+        reader.read_exact(&mut bytes)?;
+        Ok(Self(Wrapping(<i128>::from_le_bytes(bytes))))
+    }
+}
+
+impl<const K: u32> FromRandomBytes<Self> for Z2_k<K> {
+    fn has_no_bias() -> bool {
+        true
+    }
+
+    fn needs_bytes() -> usize {
+        8
+    }
+
+    fn try_from_random_bytes_inner(bytes: &[u8]) -> Option<Self> {
+        Some(Self(Wrapping(i128::from_be_bytes(bytes.try_into().ok()?))))
+    }
+}
+
+macro_rules! impl_binop_ref {
+    ($op: ident, $OpTrait: ident) => {
+        impl<'a, const K: u32> $OpTrait<&'a Self> for Z2_k<K> {
+            type Output = Self;
+
+            fn $op(self, rhs: &'a Self) -> Self::Output {
+                Self(self.0.$op(&rhs.0))
+            }
+        }
+
+        impl<'a, const K: u32> $OpTrait<&'a mut Self> for Z2_k<K> {
+            type Output = Self;
+
+            fn $op(self, rhs: &'a mut Self) -> Self::Output {
+                Self(self.0.$op(&rhs.0))
+            }
+        }
+    };
+}
+
+impl_binop_ref!(add, Add);
+impl_binop_ref!(sub, Sub);
+impl_binop_ref!(mul, Mul);
+
+macro_rules! impl_binop_assign_ref {
+    ($op: ident, $OpTrait: ident) => {
+        impl<'a, const K: u32> $OpTrait<&'a Self> for Z2_k<K> {
+            fn $op(&mut self, rhs: &'a Self) {
+                self.0.$op(&rhs.0)
+            }
+        }
+
+        impl<'a, const K: u32> $OpTrait<&'a mut Self> for Z2_k<K> {
+            fn $op(&mut self, rhs: &'a mut Self) {
+                self.0.$op(&rhs.0)
+            }
+        }
+    };
+}
+
+impl_binop_assign_ref!(add_assign, AddAssign);
+impl_binop_assign_ref!(sub_assign, SubAssign);
+impl_binop_assign_ref!(mul_assign, MulAssign);
+
+impl<'a, const K: u32> Sum<&'a Self> for Z2_k<K> {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |acc, x| acc + x)
+    }
+}
+
+impl<'a, const K: u32> Product<&'a Self> for Z2_k<K> {
+    fn product<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::one(), |acc, x| acc * x)
+    }
+}
+
+impl<const K: u32> UniformRand for Z2_k<K> {
+    fn rand<R: Rng + ?Sized>(rng: &mut R) -> Self {
+        let bytes_needed = ((K + 7) / 8) as usize;
+        let bytes_needed = bytes_needed.min(16); // Cap at i128 size
+
+        let mut bytes = [0u8; 16];
+        rng.fill_bytes(&mut bytes[..bytes_needed]);
+        let raw_value = i128::from_le_bytes(bytes);
+
+        Self(Wrapping(Self::reduce(raw_value)))
+    }
+}
+
+impl<const K: u32> Ring for Z2_k<K> {
+    const ZERO: Self = Self(Wrapping(0));
+    const ONE: Self = Self(Wrapping(1));
+
+    fn inverse(&self) -> Option<Self> {
+        if self.0 .0 % 2 == 0 {
+            None
+        } else {
+            let self_unsigned = BigUint::from(Into::<u128>::into(*self));
+            let inv_unsigned_bigint = self_unsigned.modinv(&Self::modulus()).unwrap();
+            let inv_unsigned = inv_unsigned_bigint.to_u128().unwrap();
+            Some(Self::from(inv_unsigned))
+        }
+    }
+}
+
+impl<const K: u32> From<i128> for Z2_k<K> {
+    fn from(value: i128) -> Self {
+        Self(Wrapping(Self::reduce(value)))
+    }
+}
+
+impl<const K: u32> From<Z2_k<K>> for i128 {
+    fn from(value: Z2_k<K>) -> Self {
+        value.0 .0
+    }
+}
+
+impl<const K: u32> WithSignedRepresentative for Z2_k<K> {
+    type SignedRepresentative = i128;
+
+    fn as_signed_representative(&self) -> Self::SignedRepresentative {
+        self.0 .0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::*;
+
+    // Test the generic version with different K values
+    //test_ring!(Z2_k<8>, 100);
+    //test_ring!(Z2_k<16>, 100);
+    //test_ring!(Z2_k<32>, 100);
+    test_ring!(Z2_k<37>, 100);
+    //test_ring!(Z2_k<50>, 100);
+    //test_ring!(Z2_k<64>, 100);
+    //test_ring!(Z2_k<128>, 100);
+
+    #[test]
+    fn test_different_moduli() {
+        // Test Z2_k<8> (modulus = 256)
+        let a: Z2_k<8> = Z2_k::from(200u8);
+        let b: Z2_k<8> = Z2_k::from(100u8);
+        let c = a + b;
+
+        // Test Z2_k<4> (modulus = 16)
+        let x: Z2_k<4> = Z2_k::from(10u8);
+        let y: Z2_k<4> = Z2_k::from(8u8);
+        let z = x + y;
+
+        // Test Z2_k<37> (modulus = 2^37)
+        let a_37: Z2_k<37> = Z2_k::from(1000000000u32);
+        let b_37: Z2_k<37> = Z2_k::from(2000000000u32);
+        let c_37 = a_37 + b_37;
+
+        println!("Z2_8: {} + {} = {}", a.0 .0, b.0 .0, c.0 .0);
+        println!("Z2_4: {} + {} = {}", x.0 .0, y.0 .0, z.0 .0);
+        println!("Z2_37: {} + {} = {}", a_37.0 .0, b_37.0 .0, c_37.0 .0);
+    }
+}


### PR DESCRIPTION
z_2_k is a bit tricky because you have to reduce each ring operation to the correct instantiated modulo. Easily done with a ```reduce``` function passed to each operation function. 